### PR TITLE
Making 2771 use initializer instead of constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+ * `ERC2771Context`: removed `constructor(address)` and reverted to using `__ERC2771Context_init(address)` and `__ERC2771Context_init_unchained(address)`.
  * `AccessControl`: add a virtual `_checkRole(bytes32)` function that can be overridden to alter the `onlyRole` modifier behavior. ([#3137](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3137))
  * `EnumerableMap`: add new `AddressToUintMap` map type. ([#3150](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3150))
  * `ERC1155`: Add a `_afterTokenTransfer` hook for improved extensibility. ([#3166](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3166))

--- a/contracts/metatx/ERC2771ContextUpgradeable.sol
+++ b/contracts/metatx/ERC2771ContextUpgradeable.sol
@@ -10,11 +10,14 @@ import "../proxy/utils/Initializable.sol";
  * @dev Context variant with ERC2771 support.
  */
 abstract contract ERC2771ContextUpgradeable is Initializable, ContextUpgradeable {
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    address private immutable _trustedForwarder;
+    address private _trustedForwarder;
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address trustedForwarder) {
+    function __ERC2771Context_init(address trustedForwarder) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC2771Context_init_unchained(trustedForwarder);
+    }
+
+    function __ERC2771Context_init_unchained(address trustedForwarder) internal onlyInitializing {
         _trustedForwarder = trustedForwarder;
     }
 


### PR DESCRIPTION
Fixes #???? <!-- Fill in with issue number -->

Fixing ERC2771ContextUpgradeable which was changed to use a constructor instead of an initialize function on commit https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/2924ea3bd7536ba39fed61374c5bb2bf67207452

This reverts back to using an init function
#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [x] Changelog entry
